### PR TITLE
Fix string in create_db

### DIFF
--- a/cli/create_db.sh
+++ b/cli/create_db.sh
@@ -7,4 +7,4 @@ NAME="${NEST_USER}_$1"
 
 createdb -O $NEST_USER "$NAME"
 
-echo $'Postgres database "$NAME" created successfully!'
+echo "Postgres database '$NAME' created successfully!"


### PR DESCRIPTION
Testing the `nest db create` command, I got `Postgres database "$NAME" created successfully!` - this should fix the issue