### PR TITLE
No validate flag

### DIFF
--- a/cli/add42_subdomain.sh
+++ b/cli/add42_subdomain.sh
@@ -42,9 +42,11 @@ if ! caddy validate --config /var/nest-cli/root_caddyfile --adapter caddyfile &>
 	exit 1
 fi
 
-if ! caddy validate --config /var/nest-cli/user_caddyfile --adapter caddyfile &> /dev/null; then
-	echo "Error in user Caddyfile! Please contact the Nest admins (@nestadmins) in #nest"
-	exit 1
+if [ "$2" != "no_validate" ]; then
+	if ! caddy validate --config /var/nest-cli/user_caddyfile --adapter caddyfile &> /dev/null; then
+		echo "Error in user Caddyfile! Please contact the Nest admins (@nestadmins) in #nest"
+		exit 1
+	fi
 fi
 
 # Save Caddyfiles

--- a/cli/add_domain.sh
+++ b/cli/add_domain.sh
@@ -58,9 +58,11 @@ if ! caddy validate --config /tmp/root_caddyfile --adapter caddyfile &> /dev/nul
 	exit 1
 fi
 
-if ! caddy validate --config /tmp/user_caddyfile --adapter caddyfile &> /dev/null; then
-	echo "Error in user Caddyfile! Please contact the Nest admins (@nestadmins) in #nest"
-	exit 1
+if [ "$2" != "no_validate" ]; then
+	if ! caddy validate --config /var/nest-cli/user_caddyfile --adapter caddyfile &> /dev/null; then
+		echo "Error in user Caddyfile! Please contact the Nest admins (@nestadmins) in #nest"
+		exit 1
+	fi
 fi
 
 # Save Caddyfiles

--- a/cli/add_subdomain.sh
+++ b/cli/add_subdomain.sh
@@ -42,9 +42,11 @@ if ! caddy validate --config /var/nest-cli/root_caddyfile --adapter caddyfile &>
 	exit 1
 fi
 
-if ! caddy validate --config /var/nest-cli/user_caddyfile --adapter caddyfile &> /dev/null; then
-	echo "Error in user Caddyfile! Please contact the Nest admins (@nestadmins) in #nest"
-	exit 1
+if [ "$2" != "no_validate" ]; then
+	if ! caddy validate --config /var/nest-cli/user_caddyfile --adapter caddyfile &> /dev/null; then
+		echo "Error in user Caddyfile! Please contact the Nest admins (@nestadmins) in #nest"
+		exit 1
+	fi
 fi
 
 # Save Caddyfiles

--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -8,7 +8,7 @@ module NestCLI
   class Subdomain < Thor
     include Thor::Actions
     desc "add <name>", "Add subdomain <name>.youruser.hackclub.app to the Caddyfile"
-    option :no_validate, :type => :boolean
+    option :no_validate, :type => :boolean, :desc => "Skip validation of your user Caddyfile. Useful if you have custom Caddy plugins not available in the system Caddy installtion."
     def add(name)
       run "sudo /usr/local/nest/cli/add_subdomain.sh #{name} #{options[:no_validate] ? "no_validate" : ""}"
     end
@@ -19,7 +19,7 @@ module NestCLI
     end
 
     desc "add42 <name>", "Add subdomain <name>.youruser.hackclub.dn42 to the Caddyfile"
-    option :no_validate, :type => :boolean
+    option :no_validate, :type => :boolean, :desc => "Skip validation of your user Caddyfile. Useful if you have custom Caddy plugins not available in the system Caddy installtion."
     def add42(name)
       run "sudo /usr/local/nest/cli/add42_subdomain.sh #{name} #{options[:no_validate] ? "no_validate" : ""}"
     end

--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -8,8 +8,9 @@ module NestCLI
   class Subdomain < Thor
     include Thor::Actions
     desc "add <name>", "Add subdomain <name>.youruser.hackclub.app to the Caddyfile"
+    option :no_validate, :type => :boolean
     def add(name)
-      run "sudo /usr/local/nest/cli/add_subdomain.sh #{name}"
+      run "sudo /usr/local/nest/cli/add_subdomain.sh #{name} #{options[:no_validate] ? "no_validate" : ""}"
     end
 
     desc "remove <name>", "Remove subdomain <name>.youruser.hackclub.app from the Caddyfile"
@@ -18,8 +19,9 @@ module NestCLI
     end
 
     desc "add42 <name>", "Add subdomain <name>.youruser.hackclub.dn42 to the Caddyfile"
+    option :no_validate, :type => :boolean
     def add42(name)
-      run "sudo /usr/local/nest/cli/add42_subdomain.sh #{name}"
+      run "sudo /usr/local/nest/cli/add42_subdomain.sh #{name} #{options[:no_validate] ? "no_validate" : ""}"
     end
 
     desc "remove42 <name>", "Remove subdomain <name>.youruser.hackclub.dn42 from the Caddyfile"
@@ -35,8 +37,9 @@ module NestCLI
   class Domain < Thor
     include Thor::Actions
     desc "add <name>", "Add a custom domain to the Caddyfile"
+    option :no_validate, :type => :boolean, :desc => "Skip validation of your user Caddyfile. Useful if you have custom Caddy plugins not available in the system Caddy installtion."
     def add(name)
-      run "sudo /usr/local/nest/cli/add_domain.sh #{name}"
+      run "sudo /usr/local/nest/cli/add_domain.sh #{name} #{options[:no_validate] ? "no_validate" : ""}"
     end
 
     desc "remove <name>", "Remove a custom domain from the Caddyfile"

--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -8,7 +8,7 @@ module NestCLI
   class Subdomain < Thor
     include Thor::Actions
     desc "add <name>", "Add subdomain <name>.youruser.hackclub.app to the Caddyfile"
-    option :no_validate, :type => :boolean, :desc => "Skip validation of your user Caddyfile. Useful if you have custom Caddy plugins not available in the system Caddy installtion."
+    option :no_validate, :type => :boolean, :desc => "Skip validation of your user Caddyfile. Useful if you have custom Caddy plugins not available in the system Caddy installation."
     def add(name)
       run "sudo /usr/local/nest/cli/add_subdomain.sh #{name} #{options[:no_validate] ? "no_validate" : ""}"
     end
@@ -19,7 +19,7 @@ module NestCLI
     end
 
     desc "add42 <name>", "Add subdomain <name>.youruser.hackclub.dn42 to the Caddyfile"
-    option :no_validate, :type => :boolean, :desc => "Skip validation of your user Caddyfile. Useful if you have custom Caddy plugins not available in the system Caddy installtion."
+    option :no_validate, :type => :boolean, :desc => "Skip validation of your user Caddyfile. Useful if you have custom Caddy plugins not available in the system Caddy installation."
     def add42(name)
       run "sudo /usr/local/nest/cli/add42_subdomain.sh #{name} #{options[:no_validate] ? "no_validate" : ""}"
     end
@@ -37,7 +37,7 @@ module NestCLI
   class Domain < Thor
     include Thor::Actions
     desc "add <name>", "Add a custom domain to the Caddyfile"
-    option :no_validate, :type => :boolean, :desc => "Skip validation of your user Caddyfile. Useful if you have custom Caddy plugins not available in the system Caddy installtion."
+    option :no_validate, :type => :boolean, :desc => "Skip validation of your user Caddyfile. Useful if you have custom Caddy plugins not available in the system Caddy installation."
     def add(name)
       run "sudo /usr/local/nest/cli/add_domain.sh #{name} #{options[:no_validate] ? "no_validate" : ""}"
     end


### PR DESCRIPTION
Per request of @youngchief-btw! Allows users to skip validation of the user Caddyfile when adding a domain. Useful if they have custom Caddy plugins not available in the system Caddy installation.