### PR TITLE
Make nest CLI use db-api for creating databases

### DIFF
--- a/cli/commands/db.js
+++ b/cli/commands/db.js
@@ -4,21 +4,26 @@ module.exports = function ({ program, run }) {
   db.command("create <name>")
     .description("Create a new Postgres database")
     .action(async (name) => {
-      if (/^[A-Za-z0-9_-]+$/gi.test(name)!==true) {
+      if (/^[A-Za-z0-9_-]+$/gi.test(name) !== true) {
         console.error(
           "Your database name can only include alphanumeric characters (a-Z, 0-9), hyphens (-), or underscores (_).",
         );
         process.exit(1);
       }
-      var fetchRes=await fetch(`http://127.0.0.1:998/db/${require("os").userInfo().username}_${name}`, {
-        method: "PUT"
-      });
-      switch(fetchRes.status) {
+      var fetchRes = await fetch(
+        `http://127.0.0.1:998/db/${require("os").userInfo().username}_${name}`,
+        {
+          method: "PUT",
+        },
+      );
+      switch (fetchRes.status) {
         case 200:
-          console.log(`Successfully created database with name ${require("os").userInfo().username}_${name}`);
+          console.log(
+            `Successfully created database with name ${require("os").userInfo().username}_${name}`,
+          );
           break;
         default:
-          var errMsg=await fetchRes.json();
+          var errMsg = await fetchRes.json();
           console.error(errMsg.message);
       }
     });

--- a/cli/commands/db.js
+++ b/cli/commands/db.js
@@ -3,13 +3,23 @@ module.exports = function ({ program, run }) {
 
   db.command("create <name>")
     .description("Create a new Postgres database")
-    .action((name) => {
-      if (/[^a-z0-9]/gi.test(name)) {
+    .action(async (name) => {
+      if (/^[A-Za-z0-9_-]+$/gi.test(name)!==true) {
         console.error(
-          "Your database name can only include alphanumeric characters (a-Z, 0-9)",
+          "Your database name can only include alphanumeric characters (a-Z, 0-9), hyphens (-), or underscores (_).",
         );
         process.exit(1);
       }
-      run(`sudo -u postgres /usr/local/nest/cli/helpers/create_db.sh ${name}`);
+      var fetchRes=await fetch(`http://127.0.0.1:998/db/${require("os").userInfo().username}_${name}`, {
+        method: "PUT"
+      });
+      switch(fetchRes.status) {
+        case 200:
+          console.log(`Successfully created database with name ${require("os").userInfo().username}_${name}`);
+          break;
+        default:
+          var errMsg=await fetchRes.json();
+          console.error(errMsg.message);
+      }
     });
 };

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,5 +12,6 @@
   },
   "devDependencies": {
     "prettier": "^3.3.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
This PR makes the nest CLI use the Postgres database management API added in #94 for creating databases.
All prerequisites are currently set up, so this should work immediately post-merge.