### PR TITLE
Add JSON endpoints to cabinet

### DIFF
--- a/cabinet/caddy_migrate.js
+++ b/cabinet/caddy_migrate.js
@@ -1,31 +1,31 @@
 const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
-const data = JSON.parse("./caddyfile.json")
+const data = JSON.parse("./caddyfile.json");
 
 const set = [];
 const routes = data.apps.http.servers.srv0.routes;
 
-routes.forEach(route => {
-    const match = route.match && route.match[0];
-    const handle = route.handle && route.handle[0];
+routes.forEach((route) => {
+  const match = route.match && route.match[0];
+  const handle = route.handle && route.handle[0];
 
-    if (match && match.host && handle && handle.routes) {
-        const proxyRoute = handle.routes[0].handle[0];
-        if (proxyRoute.handler === 'reverse_proxy') {
-            const proxyDial = proxyRoute.upstreams[0].dial;
-            match.host.forEach(hostname => {
-                if (!hostname || !proxyDial) return
-                const match = proxyDial.match(/\/home\/([^\/]+)\//);
-                const username = (match && match[1]) ? match[1] : "root"
+  if (match && match.host && handle && handle.routes) {
+    const proxyRoute = handle.routes[0].handle[0];
+    if (proxyRoute.handler === "reverse_proxy") {
+      const proxyDial = proxyRoute.upstreams[0].dial;
+      match.host.forEach((hostname) => {
+        if (!hostname || !proxyDial) return;
+        const match = proxyDial.match(/\/home\/([^\/]+)\//);
+        const username = match && match[1] ? match[1] : "root";
 
-                set.push({ domain: hostname, proxy: proxyDial, username: username });
-            });
-        }
+        set.push({ domain: hostname, proxy: proxyDial, username: username });
+      });
     }
+  }
 });
 async function main() {
-    await prisma.domain.createMany({
-        data: set
-    })
+  await prisma.domain.createMany({
+    data: set,
+  });
 }
-main()
+main();

--- a/cabinet/index.ts
+++ b/cabinet/index.ts
@@ -65,12 +65,14 @@ app.get("/list", async (req, res) => {
 });
 
 app.get("/list/json", async (req, res) => {
-  res.json(await prisma.domain.findMany({
-    where: {
-      username: req.username,
-    },
-  }));
-})
+  res.json(
+    await prisma.domain.findMany({
+      where: {
+        username: req.username,
+      },
+    }),
+  );
+});
 
 app.post("/domain/new", async (req, res) => {
   let user = req.username;

--- a/cabinet/index.ts
+++ b/cabinet/index.ts
@@ -64,6 +64,14 @@ app.get("/list", async (req, res) => {
   res.status(200).send(text);
 });
 
+app.get("/list/json", async (req, res) => {
+  res.json(await prisma.domain.findMany({
+    where: {
+      username: req.username,
+    },
+  }));
+})
+
 app.post("/domain/new", async (req, res) => {
   let user = req.username;
   req.admin = req.username === "root" || req.username === "nest-internal";


### PR DESCRIPTION
It's currently difficult to automate changes to caddy. This PR intends to change that by adding an endpoint that returns a list of a user's domains in the form of JSON.