### PR TITLE
Enable Prometheus metrics for Caddy

### DIFF
--- a/cabinet/utils.ts
+++ b/cabinet/utils.ts
@@ -55,6 +55,7 @@ export async function reloadCaddy() {
             errors: {
               routes: [], // error routing
             },
+            metrics: {}, // enable metrics: https://caddyserver.com/docs/metrics
           },
         },
       },


### PR DESCRIPTION
This will make it possible for https://grafana.hackclub.app to show information about caddy's current state. See https://caddyserver.com/docs/metrics for more information about caddy's metrics functionality.