### PR TITLE
[cabinet] remove .env from version control

### DIFF
--- a/cabinet/.env.example
+++ b/cabinet/.env.example
@@ -2,3 +2,4 @@ CADDY_SOCKET_PATH="/run/caddy/caddy-admin.sock"
 CADDY_ADMIN_PATH="http://localhost/load"
 DATABASE_URL="postgresql://caddy@localhost/caddy?host=%2Frun%2Fpostgresql"
 PORT=999
+RNDC_KEY=THIS-IS-A-CREDENTIAL-AND-THE-REASON-WHY-THIS-IS-NO-LONGER-IN-VERSION-CONTROL

--- a/cabinet/.gitignore
+++ b/cabinet/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+# Has credentials (BIND rndc key). Permissions of /usr/local/nest/cabinet/.env should be root:root 0600, run `setfacl -m user:caddy:r--` after to let cabinet access it.
+.env


### PR DESCRIPTION
This is a preemptive measure to avoid handing credentials to an attacker.