### PR TITLE
Allow to add subdomain if domain is already verified

### DIFF
--- a/cabinet/index.ts
+++ b/cabinet/index.ts
@@ -118,7 +118,7 @@ app.post("/domain/new", async (req, res) => {
     },
   });
 
-  const isAlreadyVerified = domains.some(domainObj => req.body.domain.endsWith(domainObj.domain));
+  const isAlreadyVerified = domains.some(domainObj => req.body.domain.endsWith("."+domainObj.domain));
   
   // Proceed as a regular domain
   if (!(await checkVerification(req.body.domain, user)) && !req.admin && !isAlreadyVerified) {
@@ -153,9 +153,10 @@ app.post("/domain/new", async (req, res) => {
         ${req.body.domain} added. (${req.body.proxy || `unix//home/${user}/.${req.body.domain}.webserver.sock`})`,
       );
   } else {
+    return res
       .status(200)
       .send(
-        `Dib\n${req.body.domain} added. (${req.body.proxy || `unix//home/${user}/.${req.body.domain}.webserver.sock`})`,
+        `${req.body.domain} added. (${req.body.proxy || `unix//home/${user}/.${req.body.domain}.webserver.sock`})`,
       );
   }
 });

--- a/cabinet/index.ts
+++ b/cabinet/index.ts
@@ -112,8 +112,16 @@ app.post("/domain/new", async (req, res) => {
       );
   }
 
+  const domains = await prisma.domain.findMany({
+    where: {
+      username: req.username,
+    },
+  });
+
+  const isAlreadyVerified = domains.some(domainObj => req.body.domain.endsWith(domainObj.domain));
+  
   // Proceed as a regular domain
-  if (!(await checkVerification(req.body.domain, user)) && !req.admin) {
+  if (!(await checkVerification(req.body.domain, user)) && !req.admin && !isAlreadyVerified) {
     return res.status(401).send(
       stripIndent`
         The domain \`${req.body.domain}\` is not verified.
@@ -137,11 +145,19 @@ app.post("/domain/new", async (req, res) => {
     },
   });
   await reloadCaddy();
-  return res
-    .status(200)
-    .send(
-      `${req.body.domain} added. (${req.body.proxy || `unix//home/${user}/.${req.body.domain}.webserver.sock`})`,
-    );
+  if (!isAlreadyVerified) {
+    return res
+      .status(200)
+      .send(stripIndent`
+        Make sure to set the CNAME record on your domain (${req.body.domain}) to \`${user}.hackclub.app\`.
+        ${req.body.domain} added. (${req.body.proxy || `unix//home/${user}/.${req.body.domain}.webserver.sock`})`,
+      );
+  } else {
+      .status(200)
+      .send(
+        `Dib\n${req.body.domain} added. (${req.body.proxy || `unix//home/${user}/.${req.body.domain}.webserver.sock`})`,
+      );
+  }
 });
 
 app.post("/domain/delete", async (req, res) => {


### PR DESCRIPTION
If the domain (ex: `myname.com`) is already verified, you can add a subdomain without verifing it (ex: `hey.myname.com`).
For public domains like `is-a.dev`, if they have `mathias.is-a.dev`, they can't add `kayla.is-a.dev` because they haven't verified `is-a.dev`