### PR TITLE
Update system information with Debian 13

### DIFF
--- a/website/components/hero.tsx
+++ b/website/components/hero.tsx
@@ -243,19 +243,19 @@ export default function Hero() {
         {isExpanded && (
           <pre className="hidden text-xs transition-all duration-300 sm:block xl:text-sm 2xl:text-base">
             {`
- __________________    orpheus@nest 
-< Welcome to Nest! >   ----------- 
- ------------------    OS: Debian GNU/Linux 12 (bookworm) x86_64 
-          \\            Host: KVM/QEMU (Standard PC (i440FX + PIIX, 1996) pc-i440fx-8.1) 
-           \\           Kernel: 6.1.0-21-amd64 
-            \\  __      Uptime: 22 days, 2 hours, 1 min 
-              / _)     Packages: 1448 (dpkg), 104 (nix-user), 51 (nix-default) 
-     _.----._/ /       Shell: bash 5.2.15 
-    /         /        Resolution: 1280x800 
- __/ (| | (  |         Terminal: /dev/pts/88 
-/__.-'|_|--|_|         CPU: AMD EPYC 9454P (80) @ 2.749GHz 
-                       GPU: 00:02.0 Vendor 1234 Device 1111 
-                       Memory: 77808MiB / 150865MiB
+ __________________    orpheus@nest
+< Welcome to Nest! >   -----------
+ ------------------    OS: Debian GNU/Linux 13 (trixie) x86_64
+          \\            Host: KVM/QEMU (Standard PC (i440FX + PIIX, 1996) pc-i440fx-9.2)
+           \\           Kernel: 6.12.35+deb13-amd64
+            \\  __      Uptime: 22 days, 2 hours, 1 min
+              / _)     Packages: 1448 (dpkg), 104 (nix-user), 51 (nix-default)
+     _.----._/ /       Shell: bash 5.2.37
+    /         /        Resolution: 1280x800
+ __/ (| | (  |         Terminal: /dev/pts/0
+/__.-'|_|--|_|         CPU: AMD EPYC 9454P (80) @ 2.749GHz
+                       GPU: 00:02.0 Vendor 1234 Device 1111
+                       Memory: 178875MiB / 231508MiB
             `}
           </pre>
         )}

--- a/website/components/hero.tsx
+++ b/website/components/hero.tsx
@@ -255,7 +255,7 @@ export default function Hero() {
  __/ (| | (  |         Terminal: /dev/pts/0
 /__.-'|_|--|_|         CPU: AMD EPYC 9454P (80) @ 2.749GHz
                        GPU: 00:02.0 Vendor 1234 Device 1111
-                       Memory: 178875MiB / 231508MiB
+                       Memory: 210423MiB / 231508MiB
             `}
           </pre>
         )}

--- a/website/components/info.tsx
+++ b/website/components/info.tsx
@@ -82,7 +82,7 @@ const SpecsContent: React.FC = () => (
       </p>
       <ul className="mt-2 list-inside list-disc">
         <li>Secure VM (NixOS): Hosts critical services</li>
-        <li>Nest VM (Debian 12): User-accessible environment</li>
+        <li>Nest VM (Debian 13): User-accessible environment</li>
       </ul>
       <p className="mt-2">
         <Link


### PR DESCRIPTION
Nest (or at least the user/Nest VM) is running Debian 13 (Trixie) now so the information on the website needs to be updated from Bookworm to Trixie.