### PR TITLE
fix(cabinet): Rejecting valid domain names

### DIFF
--- a/cabinet/index.ts
+++ b/cabinet/index.ts
@@ -78,7 +78,7 @@ app.get("/list/json", async (req, res) => {
 app.post("/domain/new", async (req, res) => {
   let user = req.username;
   req.admin = req.username === "root" || req.username === "nest-internal";
-  if (!validator.isFQDN(req.body.domain) || !/^([a-z0-9-]+\.)*dn42$/i.test(req.body.domain)) {
+  if (!(validator.isFQDN(req.body.domain) || /^([a-z0-9-]+\.)*dn42$/i.test(req.body.domain))) {
     return res
       .status(400)
       .send(
@@ -164,7 +164,7 @@ app.post("/domain/new", async (req, res) => {
 app.post("/domain/delete", async (req, res) => {
   let user = req.username;
 
-  if (!validator.isFQDN(req.body.domain)) {
+  if (!(validator.isFQDN(req.body.domain) || /^([a-z0-9-]+\.)*dn42$/i.test(req.body.domain))) {
     return res
       .status(400)
       .send(


### PR DESCRIPTION
`nest caddy add` returning "This domain is not a valid domain name. Please choose a valid domain name." for valid domains

![](https://hc-cdn.hel1.your-objectstorage.com/s/v3/c1996ce4c8612f3e644c1900200fa5178b07637e_screenshot_from_2025-08-01_20-47-23.png)

Source: hackclub/nest#128