### PR TITLE
Poll for user creation every minute until 10 minutes

### DIFF
--- a/quetzal/src/actions/approve.ts
+++ b/quetzal/src/actions/approve.ts
@@ -103,8 +103,8 @@ export function approve(app: Slack.App) {
       }
       console.log(`Password set for ${username}`);
 
-      // Delay 6 minutes to allow time for caching
-      await new Promise((resolve) => setTimeout(resolve, 1000 * 60 * 6));
+      // Delay 7 minutes to allow time for cache refresh (should refresh every 5 minutes, but adding an extra 2min buffer)
+      await new Promise((resolve) => setTimeout(resolve, 1000 * 60 * 7));
 
       await setup_script(username);
       await home_script(username);

--- a/quetzal/src/actions/approve.ts
+++ b/quetzal/src/actions/approve.ts
@@ -120,8 +120,6 @@ export function approve(app: Slack.App) {
         checks++;
       }
 
-      // Delay 7 minutes to allow time for cache refresh (should refresh every 5 minutes, but adding an extra 2min buffer)
-
       await setup_script(username);
       await home_script(username);
       await add_root_caddyfile_config(username);

--- a/quetzal/src/actions/approve.ts
+++ b/quetzal/src/actions/approve.ts
@@ -7,6 +7,7 @@ import {
   setup_script,
   home_script,
   set_authorized_keys,
+  is_user_created,
 } from "../os/os_functions.js";
 import markdown_message from "../blocks/markdown_message.js";
 
@@ -103,8 +104,23 @@ export function approve(app: Slack.App) {
       }
       console.log(`Password set for ${username}`);
 
+      let userCreated = is_user_created(username);
+      let checks = 0;
+      while (!userCreated) {
+        // Cancel and alert if it's been more than 10 minutes
+        if (checks >= 10) {
+          throw new Error(
+            `User ${username} is not on the Nest VM after 10 minutes`,
+          );
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 1000 * 60));
+        userCreated = is_user_created(username);
+
+        checks++;
+      }
+
       // Delay 7 minutes to allow time for cache refresh (should refresh every 5 minutes, but adding an extra 2min buffer)
-      await new Promise((resolve) => setTimeout(resolve, 1000 * 60 * 7));
 
       await setup_script(username);
       await home_script(username);

--- a/quetzal/src/os/os_functions.ts
+++ b/quetzal/src/os/os_functions.ts
@@ -74,3 +74,11 @@ export async function set_authorized_keys(user: string, keys: string[]) {
 
   console.log(stdout);
 }
+
+export async function is_user_created(username: string) {
+  const { stdout, stderr } = await execPromise(`id ${username}`);
+
+  if (stderr) console.error(stderr);
+
+  return !stdout.includes("no such user");
+}


### PR DESCRIPTION
Still seeing some user creation errors where the scripts try to run when the user isn't created. This PR makes sure that doesn't happen by waiting until the user is created (or throwing an error if it's been 10 minutes!).