### PR TITLE
Show static user count while count API broken

### DIFF
--- a/website/components/showcase.tsx
+++ b/website/components/showcase.tsx
@@ -34,9 +34,10 @@ export default function Showcase({ projects }: ShowcaseProps) {
   return (
     <section className="flex flex-col items-center gap-y-4 px-4 py-8 font-dm-mono text-white lg:px-16 lg:py-12 2xl:px-32 2xl:py-16">
       <h2 className="px-2 text-center text-3xl font-medium sm:text-3xl md:text-4xl 2xl:text-5xl">
-        Join <span className="text-HCPurpleText">{count} other teens</span>{" "}
+        Join <span className="text-HCPurpleText">6,762 other teens</span>{" "} 
         using Nest
-      </h2>
+      </h2> 
+      {/* TODO: Replace static number with {count} once the API is stable */}
       <p className="p-4 text-center text-lg 2xl:text-xl">
         See what fellow &quot;birds&quot; are hosting on Nest!
       </p>


### PR DESCRIPTION
Replace dynamic count with static number for display.

The number is just how many users are in the #nest Slack channel on the date of commit